### PR TITLE
fix: missing keydb service in stack

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -4,7 +4,7 @@ import concurrently from 'concurrently';
 
 const commands: { [key: string]: string } = {
   'client': 'yarn dev --host --port 3001',
-  'server': 'REVOLT_MONGO_URI=mongodb://localhost ROCKET_ADDRESS=0.0.0.0 cargo run --bin revolt',
+  'server': 'REVOLT_MONGO_URI=mongodb://localhost REVOLT_REDIS_URI=redis://localhost/ ROCKET_ADDRESS=0.0.0.0 cargo run --bin revolt',
   'autumn': 'AUTUMN_S3_ENDPOINT=http://localhost:9050 AUTUMN_HOST=0.0.0.0:3000 AUTUMN_MONGO_URI=mongodb://localhost cargo run',
   'january': 'cargo run',
 }
@@ -24,7 +24,8 @@ export default class Run extends Command {
 
     let tasks: string[] = [
       `docker run --rm -e MINIO_ROOT_USER=minioautumn -e MINIO_ROOT_PASSWORD=minioautumn -p 9050:9000 -v "${cwd}/data/minio:/data" minio/minio server /data`,
-      `docker run --rm -p 27017:27017 -v "${cwd}/data/mongodb:/data/db" mongo`
+      `docker run --rm -p 27017:27017 -v "${cwd}/data/mongodb:/data/db" mongo`,
+      `docker run --rm -p 6379:6379 eqalpha/keydb`
     ];
 
     for (let project of config.projects) {


### PR DESCRIPTION
Adds the keydb service to the docker Task run with `revolt run` with the `REVOLT_REDIS_URI` configuration for the server that where missing from the stack before